### PR TITLE
:bouncer.core/errors is now removed before validation

### DIFF
--- a/src/bouncer/core.clj
+++ b/src/bouncer/core.clj
@@ -150,7 +150,7 @@ If you'd like to know more about the motivation behind `bouncer`, check the
         step-pairs (vec (interleave (repeat ignore) wrap-calls))]
     `((m/domonad m/state-m
                  ~(assoc step-pairs (- (count step-pairs) 2) result)
-                 ~result) ~m)))
+                 ~result) (dissoc ~m ::errors))))
 
 ;; ## Public API
 

--- a/test/bouncer/core_test.clj
+++ b/test/bouncer/core_test.clj
@@ -122,7 +122,15 @@
     (let [[result map] (core/validate {:name "Leo"}
                                       :name v/required)]
       (is (true? (and (empty? result)
-                      (nil? (::core/errors map))))))))
+                      (nil? (::core/errors map)))))))
+
+  (testing "revalidation of map with bouncer.core/errors key"
+    (let [[result-error map-error] (core/validate {} :name v/required)
+          corrected-map            (assoc map-error :name "Joe")
+          [result map]             (core/validate corrected-map :name v/required)]
+      (is (and (nil? result)
+               (nil? (::core/errors map)))
+          "Expected no errors after second validation"))))
 
 (deftest coll-validations
   (let [valid-map   {:name "Leo" :pets [{:name "Aragorn"} {:name "Gandalf"}]}
@@ -230,5 +238,5 @@
                                    :mobile (v/custom #(string? %) :message "wrong format")
                                    :car (v/member ["Ferrari" "Mustang" "Mini"])
                                    :dob v/number
-                                   [:passport :number] v/positive 
+                                   [:passport :number] v/positive
                                    [:address :past] (v/every #(not (nil? (:country %)))))))))))


### PR DESCRIPTION
``` clojure
(let [error_result     (bouncer.core/validate {:x "thing"} :x bouncer.validators/number)
      corrected-map (assoc (second error_result) :x 5)
      new_result      (bouncer.core/validate corrected-map :x bouncer.validators/number)]
  (println "After first validation: " error_result)  
  (println "After second validation attempt: " new_result))

;; After first validation:  [{:x (x must be a number)} {:bouncer.core/errors {:x (x must be a number)}, :x thing}]
;; After second validation attempt:  [nil {:x 5}]
```
