### PR TITLE
Implemented email address validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - remove `validators/defvalidatorset` macro in favor of standard maps
 - Updated README
 - Updated docstrings
+- Added email validation
 
 ## 0.2.3 (12/08/2013)
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ I didn't spend a whole lot of time on *bouncer* so it only ships with the valida
 
 - `bouncer.validators/number`
 
+- `bouncer.validators/email`
+
 - `bouncer.validators/positive`
 
 - `bouncer.validators/member`

--- a/src/bouncer/validators.clj
+++ b/src/bouncer/validators.clj
@@ -133,3 +133,14 @@
   {:default-message-format "%s must satisfy the given pattern" :optional true}
   [value re]
   ((complement empty?) (re-seq re value)))
+
+(defvalidator email
+  "Validates value is an email address.
+
+  It implements a simple check to verify there's only a '@' and
+  at least one point after the '@'
+
+  For use with validation functions such as `validate` or `valid?`"
+  {:default-message-format "%s must be a valid email address"}
+  [value]
+  (and (required value) (matches value #"^[^@]+@[^@\\.]+[\\.].+")))

--- a/test/bouncer/validators_test.clj
+++ b/test/bouncer/validators_test.clj
@@ -139,3 +139,16 @@
                   :phone [[v/matches #"^\d+$"]]))
     (is (not (core/valid? {:phone "NaN"}
                   :phone [[v/matches #"^\d+$"]])))))
+
+(deftest email-validator
+  (testing "can match typical legal emails"
+    (is (core/valid? {:email "test@googlexyz.com"} :email [[v/email]]))
+    (is (core/valid? {:email "test+blabla@googlexyz.com"} :email [[v/email]]))
+    (is (core/valid? {:email "test@googlexyz.co.uk"} :email [[v/email]])))
+  (testing "will reject invalid emails"
+    (is (not (core/valid? {:email nil} :email [[v/email]])))
+    (is (not (core/valid? {:email ""} :email [[v/email]])))
+    (is (not (core/valid? {:email "test"} :email [[v/email]])))
+    (is (not (core/valid? {:email "test@"} :email [[v/email]])))
+    (is (not (core/valid? {:email "test@googlexyz"} :email [[v/email]])))
+    (is (not (core/valid? {:email "@google.xyz.com"} :email [[v/email]])))))


### PR DESCRIPTION
Interested in adding an email address validation?

I implemented a simple one, given the difficulty of writing an all-comprehensive email validation (see
http://stackoverflow.com/questions/624581/what-is-the-best-java-email-address-validation-method
http://davidcel.is/blog/2012/09/06/stop-validating-email-addresses-with-regex/ )

The proposed email validation checks the existence of one '@' and at least one point after the '@'
