### PR TITLE
Validators added: integer, string, boolean, in-range

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,9 +491,17 @@ I didn't spend a whole lot of time on *bouncer* so it only ships with the valida
 
 - `bouncer.validators/number`
 
+- `bouncer.validators/integer`
+
+- `bouncer.validators/string`
+
+- `bouncer.validators/boolean`
+
 - `bouncer.validators/email`
 
 - `bouncer.validators/positive`
+
+- `bouncer.validators/in-range`
 
 - `bouncer.validators/member`
 

--- a/src/bouncer/validators.clj
+++ b/src/bouncer/validators.clj
@@ -83,6 +83,38 @@
   [maybe-a-number]
   (number? maybe-a-number))
 
+(defvalidator integer
+  "Validates maybe-an-int is a valid integer.
+
+  For use with validation functions such as `validate` or `valid?`"
+  {:default-message-format "%s must be an integer"}
+  [maybe-an-int]
+  (integer? maybe-an-int))
+
+(defvalidator boolean
+  "Validates maybe-a-boolean is a valid boolean.
+
+  For use with validation functions such as `validate` or `valid?`"
+  {:default-message-format "%s must be a boolean"}
+  [maybe-a-boolean]
+  (or (= false maybe-a-boolean)
+      (= true maybe-a-boolean)))
+
+(defvalidator string
+  "Validates maybe-a-string is a valid string.
+
+  For use with validation functions such as `validate` or `valid?`"
+  {:default-message-format "%s must be a string"}
+  [maybe-a-string]
+  (string? maybe-a-string))
+
+(defvalidator in-range
+  "Validates number is inside specified range [from to].
+
+  For use with validation functions such as `validate` or `valid?`"
+  {:default-message-format "%s must be in a specified range"}
+  [value [from to]]
+  (<= from value to))
 
 (defvalidator positive
   "Validates number is a number and is greater than zero.

--- a/test/bouncer/validators_test.clj
+++ b/test/bouncer/validators_test.clj
@@ -21,8 +21,8 @@
   {:postcode v/required})
 
 (def person-validator
-  {:name v/required
-   :age [v/required v/number]
+  {:name [v/required v/string]
+   :age [v/required v/number v/integer]
    :address address-validator})
 
 (def deep-validator
@@ -126,12 +126,34 @@
     (is (core/valid? {:field1 :a}
                           items-validator-set))))
 
-
+(deftest boolean-validator
+  (testing "value must be a boolean "
+    (is (core/valid? {:active true} 
+                     :active v/boolean))
+    (is (core/valid? {:active false} 
+                     :active v/boolean))
+    (is (not (core/valid? {:active "false"} 
+                          :active v/boolean)))
+    (is (not (core/valid? {:active 0} 
+                          :active v/boolean)))))
 
 (deftest range-validator
   (testing "presence of value in the given range"
+    (is (core/valid? {:age 4} 
+                     :age [[v/in-range [0 5]]]))
+    (is (not (core/valid? {:age 10}
+                          :age [[v/in-range [0 9]]])))
+    (is (core/valid? {:rating 3.7} 
+                     :rating [[v/in-range [0 4]]]))
+    (is (core/valid? {:rating 10.0}
+                     :rating [[v/in-range [0 10]]]))
+    (is (not (core/valid? {:rating 10.1}
+                     :rating [[v/in-range [0 10]]])))))
+
+(deftest member-validator
+  (testing "presence of value in a collection"
     (is (core/valid? {:age 4}
-                  :age [[v/member (range 5)]]))
+                     :age [[v/member (range 5)]]))
     (is (not (core/valid? {:age 5}
                           :age [[v/member (range 5)]])))))
 


### PR DESCRIPTION
Added four more validators.

`integer` - needed to avoid decimal values, which are passes number validator
`string`/`boolean` - if we get some untrusted data and it must match the type, also useful for api clients validation to skip and not process broken requests
`in-range` - member is not acceptable for range checking, because it is slow for wide ranged (-1e9, 1e9) and doesn't handle decimals `(valid? {:rating 3.7} :rating [[member (range 5)]]) => false`

Few tests added and doc updated as well.