### PR TITLE
Fixes #36: All validators are optional by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ As an example, here's a simplified version of the `bouncer.validators/number` va
 Options is a map of key/value pairs where:
 
 - `:default-message-format` - to be used when clients of this validator don't provide one
-- `:optional` - a boolean indicating if this validator should only trigger for keys that have a value different than `nil`. Defaults to false.
+- `:optional` - a boolean indicating if this validator should only trigger for keys that have a value different than `nil`. Defaults to true.
 
 That's all syntactic sugar for:
 

--- a/src/bouncer/validators.cljx
+++ b/src/bouncer/validators.cljx
@@ -21,7 +21,7 @@
   provide a message (consider using custom message functions)
 
   - `:optional` whether the validation should be run only if the given key has
-  a non-nil value in the map. Defaults to false.
+  a non-nil value in the map. Defaults to true.
 
   or any other key-value pair which will be available in the validation result
   under the `:metadata` key.
@@ -53,8 +53,9 @@
         [fn-meta [args & body]] (if (map? (first options))
                                   [(first options) (next options)]
                                   [nil options])
-        fn-meta (assoc fn-meta
-                       :validator (keyword (str *ns*) (str name)))]
+        fn-meta (merge {:optional true}
+                       fn-meta
+                       {:validator (keyword (str *ns*) (str name))})]
     (let [arglists ''([name])]
       `(do (def ~name (with-meta (fn ~name
                                    ([~@args]
@@ -69,7 +70,8 @@
 
   For use with validation functions such as `validate` or `valid?`
 "
-  {:default-message-format "%s must be present"}
+  {:default-message-format "%s must be present"
+   :optional false}
   [value]
   (if (string? value)
     (not (empty? value))
@@ -79,7 +81,7 @@
   "Validates maybe-a-number is a valid number.
 
   For use with validation functions such as `validate` or `valid?`"
-  {:default-message-format "%s must be a number" :optional true}
+  {:default-message-format "%s must be a number"}
   [maybe-a-number]
   (number? maybe-a-number))
 
@@ -120,7 +122,7 @@
   "Validates number is a number and is greater than zero.
 
   For use with validation functions such as `validate` or `valid?`"
-  {:default-message-format "%s must be a positive number" :optional true}
+  {:default-message-format "%s must be a positive number"}
   [number]
   (> number 0))
 
@@ -153,7 +155,7 @@
   "Validates value satisfies the given regex pattern.
 
    For use with validation functions such as `validate` or `valid?`"
-  {:default-message-format "%s must satisfy the given pattern" :optional true}
+  {:default-message-format "%s must satisfy the given pattern"}
   [value re]
   ((complement empty?) (re-seq re value)))
 

--- a/test/bouncer/core_test.cljx
+++ b/test/bouncer/core_test.cljx
@@ -202,9 +202,9 @@
                       :mobile '({:path [:mobile], :value nil, :args nil, :message "wrong format"
                                  :metadata {:default-message-format "Custom validation failed for %s"
                                             :optional false}})
-                      :car    '({:path [:car], :value nil, :args [["Ferrari" "Mustang" "Mini"]], :message nil
+                      :car    '({:path [:car], :value "Volvo", :args [["Ferrari" "Mustang" "Mini"]], :message nil
                                  :metadata {:default-message-format "%s must be one of the values in the list"
-                                            :optional false
+                                            :optional true
                                             :validator :bouncer.validators/member}})
                       :dob    '({:path [:dob], :value "NaN", :args nil, :message nil
                                  :metadata {:default-message-format "%s must be a number"
@@ -221,11 +221,12 @@
                       :address  {:past   (list {:path [:address :past], :value [{:country nil} {:country "Brasil"}],
                                                 :args [pred-fn] :message nil
                                                 :metadata {:default-message-format "All items in %s must satisfy the predicate"
-                                                           :optional false
+                                                           :optional true
                                                            :validator :bouncer.validators/every}})}
                       }
           invalid-map {:name nil
                        :age ""
+                       :car "Volvo"
                        :passport {:number -7 :issued_by "Australia"}
                        :dob "NaN"
                        :address {:current { :country "Australia"}

--- a/test/bouncer/validators_test.cljx
+++ b/test/bouncer/validators_test.cljx
@@ -172,7 +172,6 @@
     (is (core/valid? {:email "test+blabla@googlexyz.com"} :email [[v/email]]))
     (is (core/valid? {:email "test@googlexyz.co.uk"} :email [[v/email]])))
   (testing "will reject invalid emails"
-    (is (not (core/valid? {:email nil} :email [[v/email]])))
     (is (not (core/valid? {:email ""} :email [[v/email]])))
     (is (not (core/valid? {:email "test"} :email [[v/email]])))
     (is (not (core/valid? {:email "test@"} :email [[v/email]])))


### PR DESCRIPTION
When creating a validator with defvalidator, the :optional option is now true by default.
When passing a predicate as a validator, it will still have :optional set to false, to make sure the predicate is actually run.