### PR TITLE
Bump cljs-time version to avoid warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.495"]
                  [clj-time "0.13.0"]
-                 [com.andrewmcveigh/cljs-time "0.5.0-alpha2"]]
+                 [com.andrewmcveigh/cljs-time "0.5.2"]]
 
   :profiles {:dev  {}
              :1.6  {:jdependencies [[org.clojure/clojure "1.6.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bouncer "1.0.1"
+(defproject bouncer "1.0.2"
   :description "A validation library for Clojure apps"
   :url "http://github.com/leonardoborges/bouncer"
   :license {:name "MIT License"


### PR DESCRIPTION
Would like to bump the cljs-time version to avoid warnings I get like:

10:25:52 cljs-for-v8 | WARNING: Use of undeclared Var cljs-time/core at line 605 public/javascripts/out-server-side-vd/cljs_time/core.cljs
10:25:52 cljs-for-v8 | WARNING: No such namespace: cljs-time, could not locate cljs_time.cljs, cljs_time.cljc, or JavaScript source providing "cljs-time" at line 606 public/javascripts/out-server-side-vd/cljs_time/core.cljs

This is fixed in cljs-time 0.5.0 (and later)